### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/weather_alert_agent.py
+++ b/weather_alert_agent.py
@@ -265,7 +265,7 @@ def notify(config, message):
         config.get("notifications", {}).get("stdout", {}).get("enabled", True)
         and config.get("debug_logging", False)
     ):
-        print(message)
+        print(f"[DEBUG] Prepared weather alert notification (length={len(message)})")
 
     for sender in (send_matrix, send_ntfy, send_discord, send_telegram):
         try:


### PR DESCRIPTION
Potential fix for [https://github.com/sidneyer/weather-alert-agent/security/code-scanning/1](https://github.com/sidneyer/weather-alert-agent/security/code-scanning/1)

To fix this without changing notification behavior, keep sending the full `message` to external notifiers, but stop printing full message content to stdout in debug mode. Replace the debug print with a sanitized summary that does not include message body or location details.

Best concrete fix in `weather_alert_agent.py`:
- In `notify` (around lines 263–269), replace `print(message)` with a metadata-only debug log such as message length and notifier count.
- No new imports or helper methods are required.

This addresses both variants (latitude and longitude taint) because neither value will flow to a logging sink anymore.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
